### PR TITLE
Switch link from http to https

### DIFF
--- a/.github/ISSUE_TEMPLATE/application_template.yml
+++ b/.github/ISSUE_TEMPLATE/application_template.yml
@@ -110,7 +110,7 @@ body:
 
         ***
 
-        Once you have submitted your issue you will need to fill in [this form](http://buildersprogram.toposware.com/applicationform).
+        Once you have submitted your issue you will need to fill in [this form](https://buildersprogram.toposware.com/applicationform).
         This process is conducted in two steps to ensure your personal details remain private. The form will ask the following questions. Please prepare the information beforehand to reduce your frustration with filling in forms!
 
         **Questions on the form**


### PR DESCRIPTION
Accessing http://buildersprogram.toposware.com/applicationform returns an error webpage with 'Service unavailable'. The proper form is accessible at the https://buildersprogram.toposware.com/applicationform
